### PR TITLE
Fix menus not disappearing after game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,8 +496,21 @@
   function flashBuff(txt){ setBuffText(txt); setTimeout(()=>{ if (txt.startsWith('Life')) setBuffText(''); }, 1200); }
 
   function overlay(show, html){
-    const ov=document.getElementById('overlay'); ov.hidden=!show;
-    if (show){ const card=document.getElementById('overlayCard'); card.innerHTML=html; const btn=card.querySelector('#overlayStart'); if (btn) btn.addEventListener('click',(e)=>{e.preventDefault(); startGame();},{once:true});}
+    const ov=document.getElementById('overlay');
+    const footer=document.querySelector('.footer');
+    if (show){
+      ov.hidden=false;
+      ov.style.display='grid';
+      const card=document.getElementById('overlayCard');
+      card.innerHTML=html;
+      const btn=card.querySelector('#overlayStart');
+      if (btn) btn.addEventListener('click',(e)=>{e.preventDefault(); startGame();},{once:true});
+      if (footer) footer.hidden=false;
+    } else {
+      ov.hidden=true;
+      ov.style.display='none';
+      if (footer) footer.hidden=true;
+    }
   }
 
   function resetState(){
@@ -507,10 +520,17 @@
   }
 
   function startGame(){
-    overlay(false,''); resetState(); resetShip(); spawnWave(state.level); state.running=true; initAudio(); update();
+    overlay(false,'');
+    resetState();
+    resetShip();
+    spawnWave(state.level);
+    state.running=true;
+    initAudio();
+    update();
   }
 
-  document.getElementById('startBtn').addEventListener('click',(e)=>{e.preventDefault(); startGame();});
+  const startBtn = document.getElementById('startBtn');
+  startBtn.addEventListener('click',(e)=>{e.preventDefault(); startGame();});
   overlay(true, document.querySelector('#overlay .centerCard').innerHTML);
 })();
 </script>


### PR DESCRIPTION
Fixes overlay and footer visibility after starting the game.

The `#overlay` element had a `display:grid` CSS property that prevented the `hidden` attribute from effectively hiding it. This PR explicitly toggles `style.display` for the overlay and hides the footer during gameplay to ensure all menu elements disappear correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd3f768c-d748-4971-9eb1-d5e86efca420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd3f768c-d748-4971-9eb1-d5e86efca420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

