### PR TITLE
Verify ui fix and adjust bottom menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   .row{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:8px}
 
   /* Mobile controls */
-  #touch{position:absolute;inset:auto 0 8px 0;display:flex;justify-content:center;gap:8px;pointer-events:none}
+  #touch{position:fixed;left:0;right:0;display:flex;justify-content:center;gap:8px;pointer-events:none;padding-bottom:env(safe-area-inset-bottom);z-index:1000;bottom:calc(env(safe-area-inset-bottom) + 8px)}
   .pad{display:flex;gap:8px}
   .ctl{pointer-events:auto;min-width:64px;min-height:64px;border:1px solid #2a3a49;border-radius:14px;background:#101722cc;backdrop-filter:blur(6px);touch-action:none}
   .ctl:active{transform:translateY(1px)}


### PR DESCRIPTION
Fixes the mobile bottom controls to prevent them from being hidden by the iOS Safari toolbar and safe-area.

---
<a href="https://cursor.com/background-agent?bcId=bc-72cb18d5-cd08-4834-84a3-c8a07858b10b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72cb18d5-cd08-4834-84a3-c8a07858b10b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

